### PR TITLE
Updated schema to hide most parameters.

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -49,7 +49,17 @@
       "type": "string",
       "default": "biotechx_basel_2024",
       "fa_icon": "far fa-calendar-alt",
-      "description": "Which event are you participating in?"
+      "description": "Which event are you participating in?",
+      "hidden": true
+    },
+    "outdir": {
+      "type": "string",
+      "default": "results",
+      "hidden": true
+    },
+    "ticket_number_emit_session_id": {
+      "type": "boolean",
+      "hidden": true
     }
   }
 }


### PR DESCRIPTION
For submitting the pipeline via a tablet at BiotechX, participants don't need to enter anything but their email, so this PR is hiding all other paremeters in the launchform.