### PR TITLE
Removed uuidgen and made email param mandatory

### DIFF
--- a/modules/local/enter_raffle_biotechx.nf
+++ b/modules/local/enter_raffle_biotechx.nf
@@ -17,7 +17,6 @@ process ENTER_RAFFLE_BIOTECHX {
     curl -X POST \\
         -d "entry.1764797758=${email}" \\
         -d "entry.957741798=${workflow.runName}" \\
-        -d "entry.1283336320=\$(uuidgen)" \\
         -d "entry.524404923=${platform_enabled}" \\
         "${destination}"
     """

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -18,7 +18,8 @@
           "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
           "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
         }
-      }
+      },
+      "required": ["email"]
     },
     "generic_options": {
       "title": "Generic options",


### PR DESCRIPTION
As the title says, uuidgen was removed, as it wasn't actually used anywhere really and email param is mandatory in schema now.