### PR TITLE
🔨 config: enable tower by default for raffle purposes

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -3,3 +3,8 @@ params.event                         = "ismb_2025"
 params.email                         = ""
 params.outdir                        = "results"
 params.ticket_number_emit_session_id = false
+
+tower {
+    enabled = true
+    endpoint = "https://api.cloud.seqera.io"
+}


### PR DESCRIPTION
Instructions for raffle participation don't include the `-with-tower` cli arg. That means we need to enable tower by default within the config. 