### PR TITLE
feat: set ASHG 2025  as the default event, update docs and add event config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Currently, the pipeline supports the following events:
 
 - SLAS 2025           [--event slas_2025]
 - ISMB 2025           [--event ismb_2025]
-- BiotechX 2025       [--event biotechx_2025] (default)
+- BiotechX 2025       [--event biotechx_2025]
+- ASHG 2025           [--event ashg_2025] (default)
 
 ## How to Run
 
@@ -29,7 +30,7 @@ If you are already familiar with Nextflow, you can enter the raffle the followin
 
 1. Ensure you have a Seqera Platform access token set as `TOWER_ACCESS_TOKEN` in your environment.
 2. Run the Nextflow pipeline `seqeralabs/nf-raffle`
-3. (Optional) Add `--event [event_name]` to specify one of the supported events (defaults to `biotechx_2025` if not specified).
+3. (Optional) Add `--event [event_name]` to specify one of the supported events (defaults to `ashg_2025` if not specified).
 
 Below are detailed instructions for new users.
 
@@ -91,4 +92,4 @@ export TOWER_ACCESS_TOKEN=your_token_here
 nextflow run seqeralabs/nf-raffle -with-tower
 ```
 
-Add `--event [event_name]` to specify one of the supported events (defaults to `biotechx_2025` if not specified).
+Add `--event [event_name]` to specify one of the supported events (defaults to `ashg_2025` if not specified).

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ export TOWER_ACCESS_TOKEN=your_token_here
 ### Step 5: Run the Pipeline
 
 ```bash
-nextflow run seqeralabs/nf-raffle -with-tower
+nextflow run seqeralabs/nf-raffle --email EMAIL --event EVENT -with-tower 
 ```
 
 Add `--event [event_name]` to specify one of the supported events (defaults to `ashg_2025` if not specified).

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -18,7 +18,7 @@ The simplest way to enter a raffle is to type this into your terminal:
 nextflow run seqeralabs/nf-raffle --email your.email@example.com
 ```
 
-This will enter you into the default event (BiotechX 2025).
+This will enter you into the default event (ASHG 2025).
 
 ## Command Structure
 

--- a/event_configs/ashg_2025.json
+++ b/event_configs/ashg_2025.json
@@ -1,0 +1,11 @@
+{
+  "event_name": "ASHG 2025",
+  "help": "Enter the raffle for ASHG 2025 conference. Requires only your email address to participate.",
+  "destination_url": "https://docs.google.com/forms/u/0/d/e/1FAIpQLSeerxkvIm3VMsza8nYtoaCLZEMe2ZiH88mA_cqROfR6ajWYKg/formResponse",
+  "form_fields": {
+    "email": "entry.1829806584",
+    "run_name": "entry.55593741",
+    "uuid": "entry.1298715334",
+    "platform_enabled": "entry.2075010812"
+  }
+}

--- a/main.nf
+++ b/main.nf
@@ -5,8 +5,8 @@ include { PRINT_PRIVACY_MESSAGE } from './modules/local/print_privacy_message'
 include { PUBLISH_REPORT        } from './modules/local/publish_report'
 
 workflow {
-    // Default event to biotechx_2025 if not specified
-    def event = params.event ?: 'biotechx_2025'
+    // Default event to ASHG 2025 if not specified
+    def event = params.event ?: 'ashg_2025'
 
     // Validate required parameters
     if (!params.email) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 params.help = false
-params.event = "biotechx_2025"
+params.event = "ashg_2025"
 params.email = ""
 params.outdir = "results"
 params.ticket_number_emit_session_id = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -21,9 +21,9 @@
         },
         "event": {
           "type": "string",
-          "default": "biotechx_2025",
+          "default": "ashg_2025",
           "description": "Which event are you attending?",
-          "enum": ["slas_2025", "fog_2025", "ismb_2025", "biotechx_2025"],
+          "enum": ["slas_2025", "fog_2025", "ismb_2025", "biotechx_2025", "ashg_2025"],
           "fa_icon": "fas fa-ticket-alt"
         },
         "outdir": {


### PR DESCRIPTION
This PR updates the nf-raffle pipeline to use ASHG 2025 as the default event for raffle entries.

Added `event_configs/ashg_2025.json` with ASHG 2025 Google Form configuration and entry IDs. Updated default event from biotechx_2025 to ashg_2025 in:
- `nextflow.config`
- `main.nf`
- `nextflow_schema.json` (also added to enum list)

Updated documentation to reflect ASHG 2025 as the default event:
- `README.md`
- `docs/INSTRUCTIONS.md`