### PR TITLE
fix: Make ismb_bosc_2026 the default event

### DIFF
--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -35,6 +35,9 @@ jobs:
           nextflow run . \
             --email "${{ github.event.inputs.email || 'fake.name@fakeplace.com' }}" \
             ${{ github.event.inputs.event && format('--event {0}', github.event.inputs.event) || '' }} \
+            --first_name "Fake" \
+            --last_name "Name" \
+            --affiliation "Fake Place" \
             --outdir results
 
       - name: Upload results

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ nf-raffle is a Nextflow pipeline designed to streamline the process of entering 
 
 Currently, the pipeline supports the following events:
 
-- FOG 2026            [`--event fog_2026`] (default)
-- ISMB/BOSC 2026      [`--event ismb_bosc_2026`] (requires `--first_name`, `--last_name`, and `--affiliation`)
+- ISMB/BOSC 2026      [`--event ismb_bosc_2026`] (default; requires `--first_name`, `--last_name`, and `--affiliation`)
+- FOG 2026            [`--event fog_2026`]
 
 ## How to Run
 
@@ -31,7 +31,7 @@ If you are already familiar with Nextflow, you can enter the raffle the followin
 
 1. Ensure you have a Seqera Platform access token set as `TOWER_ACCESS_TOKEN` in your environment.
 2. Run the Nextflow pipeline `seqeralabs/nf-raffle`
-3. (Optional) Add `--event [event_name]` to specify one of the supported events (defaults to `fog_2026` if not specified).
+3. (Optional) Add `--event [event_name]` to specify one of the supported events (defaults to `ismb_bosc_2026` if not specified).
 
 Below are detailed instructions for new users.
 
@@ -93,7 +93,7 @@ export TOWER_ACCESS_TOKEN=your_token_here
 nextflow run seqeralabs/nf-raffle --email EMAIL --event EVENT -with-tower 
 ```
 
-Add `--event [event_name]` to specify one of the supported events (defaults to `fog_2026` if not specified).
+Add `--event [event_name]` to specify one of the supported events (defaults to `ismb_bosc_2026` if not specified).
 
 Some events request additional details. **ISMB/BOSC 2026** requires your first and last name, and your organization:
 

--- a/main.nf
+++ b/main.nf
@@ -5,8 +5,8 @@ include { PRINT_PRIVACY_MESSAGE } from './modules/local/print_privacy_message/ma
 include { PUBLISH_REPORT        } from './modules/local/publish_report/main'
 
 workflow {
-    // Default event to FOG 2026 if not specified
-    def event = params.event ?: 'fog_2026'
+    // Default event to ISMB/BOSC 2026 if not specified
+    def event = params.event ?: 'ismb_bosc_2026'
 
     // Validate required parameters
     if (!params.email) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 params.help = false
-params.event = "fog_2026"
+params.event = "ismb_bosc_2026"
 params.email = ""
 params.affiliation = ""
 params.first_name = ""

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,11 +39,11 @@
                 },
                 "event": {
                     "type": "string",
-                    "default": "fog_2026",
+                    "default": "ismb_bosc_2026",
                     "description": "Which event are you attending?",
                     "enum": [
-                        "fog_2026",
-                        "ismb_bosc_2026"
+                        "ismb_bosc_2026",
+                        "fog_2026"
                     ],
                     "fa_icon": "fas fa-ticket-alt"
                 },


### PR DESCRIPTION
## Problem

When nf-raffle is uploaded to / launched from Seqera Platform, it defaulted to the **FOG 2026** event instead of **ISMB/BOSC 2026**.

## Root cause

Seqera Platform builds its launch form from `nextflow_schema.json`, whose `event` default was still `fog_2026`. So every Platform launch prefilled FOG rather than BOSC.

## Changes

- **`nextflow_schema.json`** — set `event` default to `ismb_bosc_2026` and move it to the front of the enum (drives the Platform launch form).
- **`nextflow.config`** — `params.event = "ismb_bosc_2026"` (CLI/local default).
- **`main.nf`** — update the `params.event ?:` fallback and comment.
- **`README.md`** — refresh the documented default.

## Notes

- `event_configs/ismb_bosc_2026.json` already exists, so the new default resolves correctly.
- `ismb_bosc_2026` declares `required_fields` (`first_name`, `last_name`, `affiliation`), so a bare run without those will now error — intended for that event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)